### PR TITLE
Create GoToTopButton component

### DIFF
--- a/examples/form/components/DefaultLayout.jsx
+++ b/examples/form/components/DefaultLayout.jsx
@@ -1,4 +1,4 @@
-import { Box } from '@tabnews/ui';
+import { Box, GoToTopButton } from '@tabnews/ui';
 
 import { Header } from './Header.jsx';
 
@@ -14,6 +14,7 @@ export function DefaultLayout({ children, containerWidth }) {
         }}>
         {children}
       </Box>
+      <GoToTopButton target="header" />
     </>
   );
 }

--- a/packages/ui/src/GoToTopButton/GoToTopButton.jsx
+++ b/packages/ui/src/GoToTopButton/GoToTopButton.jsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { ChevronUpIcon } from '@primer/octicons-react';
+import { IconButton } from '@primer/react';
+import { useEffect, useState } from 'react';
+
+/**
+ * A button that appears after scrolling past a target element and scrolls the page back to top.
+ *
+ * @param {Object} props
+ * @param {string|HTMLElement} [props.target] CSS selector string or HTMLElement to observe.
+ */
+export function GoToTopButton({ target }) {
+  const [showButton, setShowButton] = useState(false);
+
+  useEffect(() => {
+    let targetElement = null;
+
+    if (typeof target === 'string') {
+      targetElement = document.querySelector(target);
+    } else {
+      targetElement = target;
+    }
+
+    if (!targetElement) {
+      console.warn('GoToTopButton: Target element not found.');
+      return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        setShowButton(!entry.isIntersecting);
+      });
+    });
+
+    observer.observe(targetElement);
+    return () => observer.disconnect();
+  }, [target]);
+
+  function scrollToTop() {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  if (!showButton) {
+    return null;
+  }
+
+  return (
+    <>
+      <IconButton
+        variant="invisible"
+        aria-label="Retornar ao topo"
+        icon={ChevronUpIcon}
+        size="large"
+        className="go-to-top-button"
+        onClick={scrollToTop}
+        tooltipDirection="nw"
+      />
+      <style jsx="true">{`
+        .go-to-top-button {
+          position: fixed;
+          right: 0;
+          bottom: 0;
+          margin: 16px;
+        }
+      `}</style>
+    </>
+  );
+}

--- a/packages/ui/src/GoToTopButton/GoToTopButton.test.jsx
+++ b/packages/ui/src/GoToTopButton/GoToTopButton.test.jsx
@@ -1,0 +1,134 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react';
+
+import { GoToTopButton } from './GoToTopButton.jsx';
+
+const IntersectionObserver = global.IntersectionObserver;
+let lastObserver = null;
+
+const MockIntersectionObserver = vi.fn((callback) => {
+  lastObserver = {
+    callback,
+    observe: vi.fn(),
+    disconnect: vi.fn(),
+  };
+  return lastObserver;
+});
+
+global.IntersectionObserver = MockIntersectionObserver;
+
+afterEach(() => {
+  lastObserver = null;
+  MockIntersectionObserver.mockClear();
+});
+
+afterAll(() => {
+  global.IntersectionObserver = IntersectionObserver;
+});
+
+describe('ui', () => {
+  describe('GoToTopButton', () => {
+    it('does not render the button without interaction', () => {
+      render(
+        <>
+          <header></header>
+          <GoToTopButton target="header" />
+        </>,
+      );
+      expect(screen.queryByRole('button')).toBeNull();
+    });
+
+    it('renders the button when the target is a CSS selector and is not in view', () => {
+      render(
+        <>
+          <header data-testid="target"></header>
+          <GoToTopButton target="header" />
+        </>,
+      );
+      expect(screen.queryByRole('button')).toBeNull();
+
+      expect(lastObserver.observe).toHaveBeenCalledTimes(1);
+      expect(lastObserver.observe).toHaveBeenCalledWith(screen.getByTestId('target'));
+
+      act(() => lastObserver.callback([{ isIntersecting: false }]));
+      expect(screen.getByRole('button')).toBeVisible();
+    });
+
+    it('renders the button when the target is an HTMLElement and is not in view', () => {
+      const { container } = render(<div data-testid="html-element-target"></div>);
+
+      const targetElement = screen.getByTestId('html-element-target');
+
+      render(<GoToTopButton target={targetElement} />, { container: container });
+
+      expect(lastObserver.observe).toHaveBeenCalledTimes(1);
+      expect(lastObserver.observe).toHaveBeenCalledWith(targetElement);
+
+      act(() => lastObserver.callback([{ isIntersecting: false }]));
+      expect(screen.getByRole('button')).toBeVisible();
+    });
+
+    it('hides the button when the target is back in view', () => {
+      render(
+        <>
+          <div id="top"></div>
+          <GoToTopButton target="#top" />
+        </>,
+      );
+
+      act(() => lastObserver.callback([{ isIntersecting: false }]));
+      expect(screen.queryByRole('button')).not.toBeNull();
+
+      act(() => lastObserver.callback([{ isIntersecting: true }]));
+      expect(screen.queryByRole('button')).toBeNull();
+    });
+
+    it('calls window.scrollTo when the button is clicked', async () => {
+      const scrollToMock = vi.fn();
+      const originalScrollTo = window.scrollTo;
+      window.scrollTo = scrollToMock;
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <section></section>
+          <GoToTopButton target="section" />
+        </>,
+      );
+
+      act(() => lastObserver.callback([{ isIntersecting: false }]));
+      await user.click(screen.getByRole('button'));
+
+      window.scrollTo = originalScrollTo;
+
+      expect(scrollToMock).toHaveBeenCalledTimes(1);
+      expect(scrollToMock).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+    });
+
+    it('logs a warning if the target element is not found', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementationOnce(() => {});
+
+      render(<GoToTopButton target="#non-existent-element" />);
+
+      expect(consoleSpy).toHaveBeenCalledWith('GoToTopButton: Target element not found.');
+      expect(screen.queryByRole('button')).toBeNull();
+    });
+
+    it('disconnects the observer on cleanup', () => {
+      const { unmount } = render(
+        <>
+          <header></header>
+          <GoToTopButton target="header" />
+        </>,
+      );
+
+      expect(MockIntersectionObserver).toHaveBeenCalledTimes(1);
+      expect(lastObserver.observe).toHaveBeenCalledTimes(1);
+
+      unmount();
+
+      expect(lastObserver.disconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/ui/src/GoToTopButton/index.js
+++ b/packages/ui/src/GoToTopButton/index.js
@@ -1,0 +1,1 @@
+export * from './GoToTopButton.jsx';

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -1,6 +1,7 @@
 export * from './AutoThemeProvider/index.js';
 export { COLOR_MODE_COOKIE } from './constants/public.js';
 export * from './FormField/index.js';
+export * from './GoToTopButton/index.js';
 export { PrimerRoot } from './PrimerRoot/PrimerRoot.jsx';
 export { StyledComponentsRegistry } from './SCRegistry/SCRegistry.jsx';
 export * from './ThemeProvider/index.js';

--- a/packages/ui/src/index.test.js
+++ b/packages/ui/src/index.test.js
@@ -16,6 +16,7 @@ const exportedByIndex = [
   'Flash',
   'FormControl',
   'GlobalStyle',
+  'GoToTopButton',
   'Heading',
   'IconButton',
   'Label',


### PR DESCRIPTION
The component already exists on TabNews repository [here](https://github.com/filipedeschamps/tabnews.com.br/blob/b1ca6a13cf1b196c86d77dca0c732be8e077607e/pages/interface/components/GoToTopButton/index.js).

The major difference is that the `IconButton` now is not styled with the `sx` prop, since it is deprecated, and the styling is only to position it on the bottom right of the screen.

The component didn't have any tests, so all tests are new.

| Dark | Light |
| --- |--- |
| ![Button with tooltip on dark mode](https://github.com/user-attachments/assets/3bedab64-a6fe-492f-945f-3d3401fcfa5c) | ![Button with tooltip on light mode](https://github.com/user-attachments/assets/2d71f998-6a93-4c00-b012-92237b7aad0e) |