### PR TITLE
Fix/markdown css

### DIFF
--- a/packages/ui/src/Markdown/styles/editor.css
+++ b/packages/ui/src/Markdown/styles/editor.css
@@ -1,4 +1,5 @@
 .bytemd {
+  background-color: var(--bgColor-inset);
   display: inline-block;
   width: 100%;
   border-width: 1px;
@@ -20,6 +21,7 @@
 }
 
 .bytemd:focus-within {
+  background-color: var(--bgColor-default);
   border-color: var(--fgColor-accent);
   outline: 2px solid var(--fgColor-accent);
 }
@@ -65,7 +67,6 @@
 }
 
 .bytemd-body {
-  background-color: var(--bgColor-default);
   caret-color: var(--codeMirror-cursor-fgColor);
   min-height: 150px;
   overflow: auto;
@@ -398,16 +399,11 @@
 }
 
 .CodeMirror {
-  background-color: var(--bgColor-inset);
   font-family: monospace;
   direction: ltr;
   position: relative;
   height: 300px;
   overflow: hidden;
-}
-
-.CodeMirror:focus-within {
-  background-color: var(--bgColor-default);
 }
 
 .CodeMirror-lines {

--- a/packages/ui/src/Markdown/styles/editor.css
+++ b/packages/ui/src/Markdown/styles/editor.css
@@ -2,6 +2,7 @@
   background-color: var(--bgColor-inset);
   display: inline-block;
   width: 100%;
+  padding: 1px;
   border-width: 1px;
   border-style: solid;
   border-radius: 6px;
@@ -46,6 +47,7 @@
   z-index: 10;
   border: none;
   height: 100vh !important;
+  padding: 0;
 }
 
 .bytemd-fullscreen.bytemd:focus-within {

--- a/packages/ui/src/Markdown/styles/editor.css
+++ b/packages/ui/src/Markdown/styles/editor.css
@@ -377,6 +377,11 @@
   vertical-align: top;
   height: 100%;
   overflow: hidden;
+  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 14px), calc(100% - 14px) 100%, 0 100%);
+}
+
+.bytemd-fullscreen .bytemd-editor {
+  clip-path: none;
 }
 
 .bytemd-editor .CodeMirror {


### PR DESCRIPTION
- Resolve https://github.com/filipedeschamps/tabnews.com.br/pull/1884#pullrequestreview-2801316925 using `padding`.
- Ensure the resize handle remains visible in Safari on macOS using `clip-path`.