### PR TITLE
Revert "refactor(MarkdownEditor): apply `background-color` via `.byte…

### DIFF
--- a/packages/ui/src/Markdown/styles/editor.css
+++ b/packages/ui/src/Markdown/styles/editor.css
@@ -1,5 +1,4 @@
 .bytemd {
-  background-color: var(--bgColor-inset);
   display: inline-block;
   width: 100%;
   padding: 1px;
@@ -22,7 +21,6 @@
 }
 
 .bytemd:focus-within {
-  background-color: var(--bgColor-default);
   border-color: var(--fgColor-accent);
   outline: 2px solid var(--fgColor-accent);
 }
@@ -69,6 +67,7 @@
 }
 
 .bytemd-body {
+  background-color: var(--bgColor-default);
   caret-color: var(--codeMirror-cursor-fgColor);
   min-height: 150px;
   overflow: auto;
@@ -406,11 +405,16 @@
 }
 
 .CodeMirror {
+  background-color: var(--bgColor-inset);
   font-family: monospace;
   direction: ltr;
   position: relative;
   height: 300px;
   overflow: hidden;
+}
+
+.CodeMirror:focus-within {
+  background-color: var(--bgColor-default);
 }
 
 .CodeMirror-lines {


### PR DESCRIPTION
…md` container"

This reverts commit e8e38e8f41fb3e567549e3172721697764183f0e.