### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/ui":"0.5.2","packages/forms":"0.3.2","packages/helpers":"0.3.0","packages/hooks":"0.1.5","examples/form":"0.2.2","examples/markdown":"0.0.3","packages/infra":"0.0.5"}
+{"packages/ui":"0.5.3","packages/forms":"0.3.2","packages/helpers":"0.3.0","packages/hooks":"0.1.5","examples/form":"0.2.3","examples/markdown":"0.0.4","packages/infra":"0.0.5"}

--- a/examples/form/CHANGELOG.md
+++ b/examples/form/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.3](https://github.com/aprendendofelipe/tabnews/compare/form-example-v0.2.2...form-example-v0.2.3) (2025-04-29)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @tabnews/ui bumped from 0.5.2 to 0.5.3
+
 ## [0.2.2](https://github.com/aprendendofelipe/tabnews/compare/form-example-v0.2.1...form-example-v0.2.2) (2025-04-29)
 
 

--- a/examples/form/package.json
+++ b/examples/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-example",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -10,7 +10,7 @@
   "dependencies": {
     "@primer/octicons-react": "19.15.1",
     "@tabnews/forms": "0.3.2",
-    "@tabnews/ui": "0.5.2",
+    "@tabnews/ui": "0.5.3",
     "next": "15.3.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/examples/markdown/CHANGELOG.md
+++ b/examples/markdown/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.0.4](https://github.com/aprendendofelipe/tabnews/compare/markdown-example-v0.0.3...markdown-example-v0.0.4) (2025-04-29)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @tabnews/ui bumped from 0.5.2 to 0.5.3
+
 ## [0.0.3](https://github.com/aprendendofelipe/tabnews/compare/markdown-example-v0.0.2...markdown-example-v0.0.3) (2025-04-29)
 
 

--- a/examples/markdown/package.json
+++ b/examples/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-example",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tabnews/ui": "0.5.2",
+    "@tabnews/ui": "0.5.3",
     "next": "15.3.1",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,11 +32,11 @@
     },
     "examples/form": {
       "name": "form-example",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@primer/octicons-react": "19.15.1",
         "@tabnews/forms": "0.3.2",
-        "@tabnews/ui": "0.5.2",
+        "@tabnews/ui": "0.5.3",
         "next": "15.3.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -45,9 +45,9 @@
     },
     "examples/markdown": {
       "name": "markdown-example",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
-        "@tabnews/ui": "0.5.2",
+        "@tabnews/ui": "0.5.3",
         "next": "15.3.1",
         "react": "18.3.1",
         "react-dom": "18.3.1"
@@ -22197,7 +22197,7 @@
     },
     "packages/ui": {
       "name": "@tabnews/ui",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@bytemd/plugin-breaks": "^1.22.0",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.3](https://github.com/aprendendofelipe/tabnews/compare/ui-v0.5.2...ui-v0.5.3) (2025-04-29)
+
+
+### Bug Fixes
+
+* **MarkdownEditor:** Revert "refactor(MarkdownEditor): apply background-color via .bytemd container" ([4741de4](https://github.com/aprendendofelipe/tabnews/commit/4741de4a6f1d76765906c79cf7acb85cd27d610d))
+
 ## [0.5.2](https://github.com/aprendendofelipe/tabnews/compare/ui-v0.5.1...ui-v0.5.2) (2025-04-29)
 
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/ui",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "TabNews UI",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Created a release
---

<details><summary>ui: 0.5.2</summary>

## [0.5.3](https://github.com/aprendendofelipe/tabnews/compare/ui-v0.5.2...ui-v0.5.3) (2025-04-29)


### Bug Fixes

* **MarkdownEditor:** Revert "refactor(MarkdownEditor): apply background-color via .bytemd container" ([4741de4](https://github.com/aprendendofelipe/tabnews/commit/4741de4a6f1d76765906c79cf7acb85cd27d610d))
</details>

<details><summary>form-example: 0.2.3</summary>

## [0.2.3](https://github.com/aprendendofelipe/tabnews/compare/form-example-v0.2.2...form-example-v0.2.3) (2025-04-29)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @tabnews/ui bumped from 0.5.2 to 0.5.3
</details>

<details><summary>markdown-example: 0.0.4</summary>

## [0.0.4](https://github.com/aprendendofelipe/tabnews/compare/markdown-example-v0.0.3...markdown-example-v0.0.4) (2025-04-29)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @tabnews/ui bumped from 0.5.2 to 0.5.3
</details>