### PR TITLE
chore(release-please): enable pre-major version bumping

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,5 +9,7 @@
     "packages/ui": {}
   },
   "plugins": ["node-workspace"],
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "always-link-local": true
 }


### PR DESCRIPTION
This PR updates the `.release-please-config.json` file to explicitly enable pre-major version bumping.

### Changes

- Enables `bump-minor-pre-major: true`: ensures that breaking changes during `0.x` versions increment the `minor` instead of jumping to `1.0.0`.
- Enables `bump-patch-for-minor-pre-major: true`: allows minor features to trigger patch bumps during pre-1.0.0 development.

This change aligns versioning behavior with SemVer expectations for projects still in early development.